### PR TITLE
Create NerdPress::$plugin_dir_url to get the plugin root directory

### DIFF
--- a/blog-tutor-support.php
+++ b/blog-tutor-support.php
@@ -40,6 +40,11 @@ class NerdPress {
 	protected static $instance = null;
 
 	/**
+ 	 * NerdPress plugin root URL.
+ 	 */
+	public static $plugin_dir_url = '';
+
+	/**
 	 * Initialize the plugin.
 	 */
 	private function __construct() {
@@ -50,6 +55,7 @@ class NerdPress {
 			$this->admin_includes();
 		}
 
+		self::$plugin_dir_url = plugin_dir_url( __FILE__ );
 	}
 
 	/**

--- a/includes/admin-menu.php
+++ b/includes/admin-menu.php
@@ -15,7 +15,7 @@ function bt_custom_toolbar_links( $wp_admin_bar ) {
 		}		
 
 		?>
-			<link rel="stylesheet" href="<?php echo plugins_url(); ?>/blog-tutor-support/includes/css/html-admin-menu.css" type="text/css" media="all">
+			<link rel="stylesheet" href="<?php echo NerdPress::$plugin_dir_url . 'includes/css/html-admin-menu.css'; ?>" type="text/css" media="all">
 		<?php
 		
 		// Add "NerdPress" parent menu items.

--- a/includes/admin/views/html-serverinfo-field.php
+++ b/includes/admin/views/html-serverinfo-field.php
@@ -37,7 +37,7 @@ if ( $mem_show ) {
 }
 ?>
 
-<link rel="stylesheet" href="<?php echo plugins_url(); ?>/blog-tutor-support/includes/css/html-serverinfo-field-style.css" type="text/css" media="all">
+<link rel="stylesheet" href="<?php echo NerdPress::$plugin_dir_url . 'includes/css/html-serverinfo-field-style.css'; ?>" type="text/css" media="all">
 
 <?php
 $disk_total = NerdPress_Helpers::format_size( NerdPress_Helpers::get_disk_info()['disk_total'] );

--- a/includes/admin/views/html-sucuri-options-field.php
+++ b/includes/admin/views/html-sucuri-options-field.php
@@ -6,7 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 $allowlist_ips = get_option( 'cloudproxy_allowlist_ips', array() );
 
 if( count( $allowlist_ips ) > 0 ) {	
-	wp_register_script( 'clear_allowlist_js', plugins_url( '../js/bt-clearallowlist.js', __FILE__ ), array(), BT_PLUGIN_VERSION );
+	wp_register_script( 'clear_allowlist_js', esc_url( NerdPress::$plugin_dir_url . 'includes/admin/js/bt-clearallowlist.js' ), array(), BT_PLUGIN_VERSION );
 	wp_localize_script( 'clear_allowlist_js', 'clear_allowlist', array(
 		'endpoint' => admin_url( 'admin-ajax.php' ),
 		'nonce'	   => wp_create_nonce( 'clear_allowlist_secure_me' ),

--- a/includes/class-support-clearcache.php
+++ b/includes/class-support-clearcache.php
@@ -74,7 +74,7 @@ class NerdPress_Clearcache {
 	public function bt_enqueue_scripts() {
 		if ( user_can( get_current_user_id(), 'edit_posts' ) ) {
 			wp_enqueue_script( 'jquery' ); 
-			wp_register_script( 'clearcache_js', plugins_url( 'js/bt-clearcache.js', __FILE__ ), array(), BT_PLUGIN_VERSION );
+			wp_register_script( 'clearcache_js', esc_url( NerdPress::$plugin_dir_url . 'includes/js/bt-clearcache.js' ), array(), BT_PLUGIN_VERSION );
 			wp_localize_script( 'clearcache_js', 'sucuri_clearcache', array(
 				'endpoint' => admin_url( 'admin-ajax.php' ),
 				'nonce'    => wp_create_nonce( 'sucuri_clearcache_secure_me' ),

--- a/includes/class-support-cloudflare.php
+++ b/includes/class-support-cloudflare.php
@@ -185,7 +185,7 @@ class NerdPress_Cloudflare_Client {
 			return;
 		}
   	global $wp;
-  	wp_register_script( 'np_cf_js', plugins_url( 'includes/js/np-cloudflare.js', dirname( __FILE__ ) ), array( 'jquery' ), BT_PLUGIN_VERSION );
+  	wp_register_script( 'np_cf_js', esc_url( NerdPress::$plugin_dir_url . 'includes/js/np-cloudflare.js' ), array( 'jquery' ), BT_PLUGIN_VERSION );
 		wp_enqueue_script( 'np_cf_js' );  
 		wp_localize_script( 'np_cf_js', 'np_cf_ei', array(
 			'endpoint'     => admin_url( 'admin-ajax.php' ),

--- a/includes/class-support-cloudproxy.php
+++ b/includes/class-support-cloudproxy.php
@@ -34,7 +34,7 @@ class NerdPress_Cloudproxy {
 	}
 
 	public function bt_enqueue_scripts() {
-		wp_register_script( 'allowlist_js', plugins_url( 'js/bt-allowlist.js', __FILE__ ), array(), BT_PLUGIN_VERSION );
+		wp_register_script( 'allowlist_js', esc_url( NerdPress::$plugin_dir_url . 'includes/js/bt-allowlist.js' ), array(), BT_PLUGIN_VERSION );
 		wp_localize_script( 'allowlist_js', 'sucuri_allowlist', array(
 			'endpoint' => admin_url( 'admin-ajax.php' ),
 			'nonce'    => wp_create_nonce( 'sucuri_allowlist_secure_me' ),

--- a/includes/class-support-helpers.php
+++ b/includes/class-support-helpers.php
@@ -229,19 +229,22 @@ class NerdPress_Helpers {
 	 * @return void
 	 */
 	public static function display_notification( $msg ) {
-		if ( ! is_array( $msg ) )
+		if ( ! is_array( $msg ) ) {
 			$msg = array( 'status' => 1, 'msg' => $msg );
-	
+		}
+		
 		// Exit if message is empty
-		if ( $msg['msg'] == '') return;
+		if ( $msg['msg'] == '') {
+			return;
+		}
 
 		$msg_class = ( $msg['status'] ? 'np-notice' : 'error np-notice' );
-	?>
-		<link rel="stylesheet" href="<?php echo plugins_url(); ?>/blog-tutor-support/includes/css/html-notifications-style.css" type="text/css" media="all">
-		<div class="notice <?php echo $msg_class; ?>">
-			<p><img src="<?php echo esc_url( site_url() ); ?>/wp-content/plugins/blog-tutor-support/includes/images/nerdpress-icon-250x250.png" style="max-width:45px;vertical-align:middle;"><strong><?php echo $msg['msg']; ?></strong></p>
+		?>
+			<link rel="stylesheet" href="<?php echo esc_url( NerdPress::$plugin_dir_url . 'includes/css/html-notifications-style.css' ); ?>" type="text/css" media="all">
+			<div class="notice <?php echo $msg_class; ?>">
+				<p><img src="<?php echo esc_url( NerdPress::$plugin_dir_url . 'includes/images/nerdpress-icon-250x250.png' ); ?>" style="max-width:45px;vertical-align:middle;"><strong><?php echo $msg['msg']; ?></strong></p>
 			</div>
-			<?php
+		<?php
   }
 	
 	/**


### PR DESCRIPTION
There were several instances where the plugin directory (blog-tutor-support) was being hard coded. I fixed this by adding a variable at the main plugin file level and calling it from it's class (NerdPress::$plugin_dir_url).