### PR TITLE
Add debug display for our user when enabled on settings.

### DIFF
--- a/includes/admin/class-support-admin.php
+++ b/includes/admin/class-support-admin.php
@@ -140,6 +140,7 @@ class NerdPress_Admin {
 				'label' => __( 'Disable our hard coded list of excluded JS.', 'nerdpress-support' ),
 			)
 		);
+
 		// Add option to disable/enable ShortPixel bulk optimization. 
 		add_settings_field(
 			'shortpixel_bulk_optimize',
@@ -152,6 +153,21 @@ class NerdPress_Admin {
 				'id'    => 'shortpixel_bulk_optimize',
 				'label' => __( 'Un-hide ShortPixel Bulk Optimization options for users.', 'nerdpress-support' ),
 				'description' => __( 'SHORTPIXEL_HIDE_API_KEY constant ' ),
+			)
+		);
+
+		// Add option to disable/enable displaying debug messages for NerdPress users. 
+		add_settings_field(
+			'nerdpress_debug',
+			__( 'Display Debug for NerdPress', 'nerdpress-support' ),
+			array( $this, 'checkbox_nerdpress_debug_element_callback' ),
+			$settings_option,
+			'options_section',
+			array(
+				'menu'  => $settings_option,
+				'id'    => 'nerdpress_debug',
+				'label' => __( 'Enable displaying debug messages for NerdPress users.', 'nerdpress-support' ),
+				'description' => __( 'WP_DEBUG constant ' ),
 			)
 		);
 
@@ -196,36 +212,33 @@ class NerdPress_Admin {
 			)
 		);
 
-		$has_cloudflare = ( isset( $bt_options['firewall_choice'] ) && $bt_options['firewall_choice'] == 'cloudflare' );
+		// Add field Cloudflare Options
+		add_settings_field(
+			'cloudflare_zone',
+			__( 'Cloudflare DNS Zone', 'nerdpress-support' ),
+			array( $this, 'cloudflare_dns_element_callback' ),
+			$settings_option,
+			'options_section',
+			array(
+				'menu'    => $settings_option,
+				'id'      => 'cloudflare_zone',
+				'label'   => __( 'Cloudflare DNS Zone', 'nerdpress-support' ),
+				'default' => 'dns1',
+			)
+		);
 
-// 		if ( $has_cloudflare ) {
-			// Add field Cloudflare Options
-			add_settings_field(
-				'cloudflare_zone',
-				__( 'Cloudflare DNS Zone', 'nerdpress-support' ),
-				array( $this, 'cloudflare_dns_element_callback' ),
-				$settings_option,
-				'options_section',
-				array(
-					'menu'    => $settings_option,
-					'id'      => 'cloudflare_zone',
-					'label'   => __( 'Cloudflare DNS Zone', 'nerdpress-support' ),
-					'default' => 'dns1',
-				)
-			);
-			add_settings_field(
-				'cloudflare_token',
-				__( 'Cloudflare API Token', 'nerdpress-support' ),
-				array( $this, 'cloudflare_token_element_callback' ),
-				$settings_option,
-				'options_section',
-				array(
-					'menu'  => $settings_option,
-					'id'    => 'cloudflare_token',
-					'label' => __( 'Cloudflare Access Token', 'nerdpress-support' ),
-				)
-			);
-// 		}
+		add_settings_field(
+			'cloudflare_token',
+			__( 'Cloudflare API Token', 'nerdpress-support' ),
+			array( $this, 'cloudflare_token_element_callback' ),
+			$settings_option,
+			'options_section',
+			array(
+				'menu'  => $settings_option,
+				'id'    => 'cloudflare_token',
+				'label' => __( 'Cloudflare Access Token', 'nerdpress-support' ),
+			)
+		);
 
 		// Register settings.
 		register_setting( $settings_option, $settings_option, array( $this, 'validate_options' ) );
@@ -389,6 +402,7 @@ class NerdPress_Admin {
 		include dirname( __FILE__ ) . '/views/html-exclude-wp-rocket-delay-js-field.php';
 
 	}
+
 	/**
 	 * Checkbox ShortPixel Bulk Optimize element callback.
 	 *
@@ -405,6 +419,25 @@ class NerdPress_Admin {
 			$current = isset( $args['default'] ) ? $args['default'] : '0';
 		}
 		include dirname( __FILE__ ) . '/views/html-shortpixel-bulk-optimize-field.php';
+
+	}
+
+	/**
+	 * Checkbox NerdPress Debug element callback.
+	 *
+	 * @param array $args Callback arguments.
+	 */
+	public function checkbox_nerdpress_debug_element_callback( $args ) {
+		$menu    = $args['menu'];
+		$id      = $args['id'];
+		$options = get_option( $menu );
+
+		if ( isset( $options[ $id ] ) ) {
+			$current = $options[ $id ];
+		} else {
+			$current = isset( $args['default'] ) ? $args['default'] : '0';
+		}
+		include dirname( __FILE__ ) . '/views/html-nerdpress-debug-field.php';
 
 	}
 
@@ -500,7 +533,6 @@ class NerdPress_Admin {
 	 * @param array $args Callback arguments.
 	 */
 	public function cloudflare_dns_element_callback( $args ) {
-// 		print_r( $args );
 		$menu    = $args['menu'];
 		$id      = $args['id'];
 		$options = get_option( $menu );
@@ -523,7 +555,6 @@ class NerdPress_Admin {
 	 * @param array $args Callback arguments.
 	 */
 	public function cloudflare_token_element_callback( $args ) {
-// 		print_r( $args );
 		$menu    = $args['menu'];
 		$id      = $args['id'];
 		$options = get_option( $menu );

--- a/includes/admin/views/html-nerdpress-debug-field.php
+++ b/includes/admin/views/html-nerdpress-debug-field.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Checkbox field view.
+ *
+ * @package NerdPress/Admin/View
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+?>
+<input type="checkbox" id="<?php echo esc_attr( $id ); ?>" name="<?php echo esc_attr( $menu ) ?>[<?php echo esc_attr( $id ); ?>]" value="1" <?php checked( 1, $current, true ) ?> />
+<?php if ( isset( $args['label'] ) ) : ?>
+	<label for="<?php echo esc_attr( $id ); ?>"><?php echo esc_html( $args['label'] ); ?></label>
+<?php endif; ?>
+<?php if ( isset( $args['description'] ) ) : ?>
+  <p class="description"><?php echo esc_html( $args['description'] ); 
+	if ( defined( 'WP_DEBUG' ) && constant( 'WP_DEBUG' ) ) {
+		echo 'is set to true.';
+	} else {
+		echo 'is set to false.';
+	}
+  ?>
+  </p>
+<?php endif;

--- a/includes/class-support-overrides.php
+++ b/includes/class-support-overrides.php
@@ -21,6 +21,7 @@ class NerdPress_Support_Overrides {
 		self::$nerdpress_options = get_option( self::$options_array, array() ); 
 		add_action( 'init', array( $this, 'is_auto_update_set' ) );
 		add_action( 'init', array( $this, 'check_default_options' ) );
+		add_action( 'init', array( $this, 'nerdpress_debug' ) );
 		add_filter( 'wp_mail', array( $this, 'nerdpress_override_alert_email' ) );
 		if ( ! is_admin() && ! isset( self::$nerdpress_options['exclude_wp_rocket_delay_js'] ) ) {
 			add_filter( 'rocket_delay_js_exclusions', array( $this, 'nerdpress_override_rocket_delay_js_exclusions' ));
@@ -103,6 +104,19 @@ class NerdPress_Support_Overrides {
 		$excluded_strings[] = "social-pug";
 		return $excluded_strings;
 	}
+
+	/**
+ 	 * Set debug display to on if set to on in plugin settings and is NerdPress user.
+ 	 */
+  public function nerdpress_debug() {
+		if ( ! constant( 'WP_DEBUG' ) && NerdPress_Helpers::is_nerdpress() && self::$nerdpress_options['nerdpress_debug'] === '1' ) {
+
+			// Turn on error reporting.
+			error_reporting( E_ALL );
+			// Sets to display errors on screen. Use 0 to turn off.
+			ini_set( 'display_errors', 1 );
+		}
+  }
 }
 
 new NerdPress_Support_Overrides();


### PR DESCRIPTION
Cleaned up a little, my bad...

This circumvents the native WordPress debug constant and does, essentially the sameish.
Closes #128 