### PR TITLE
Add CSS to hide "trash" link in comment sources

### DIFF
--- a/includes/class-support-overrides.php
+++ b/includes/class-support-overrides.php
@@ -44,6 +44,7 @@ class NerdPress_Support_Overrides {
 		?>
 		<style type="text/css">
 			#blc-links .column-used-in .trash,
+			#blc-links .column-used-in .delete,
 			#blc-bulk-action-form option[value="bulk-trash-sources"]
 			{display: none;}
 		</style>


### PR DESCRIPTION
Adds more specific CSS to re-hide the "trash" link in comment sources in Broken Link Checker.