### PR TITLE
#289 update target for hiding logtivity settings

### DIFF
--- a/includes/class-support-overrides.php
+++ b/includes/class-support-overrides.php
@@ -39,8 +39,7 @@ class NerdPress_Support_Overrides {
 		if ( ! NerdPress_Helpers::is_nerdpress() ) {
 			remove_submenu_page( 'logs', 'logtivity-settings' );
 			remove_submenu_page( 'lgtvy-logs', 'logtivity-settings' );
-			add_filter('logtivity_hide_settings_page', 'not_np_hide_logs');
-			function not_np_hide_logs(){ return true; }
+			add_filter( 'logtivity_hide_settings_page', '__return_true' );
 		}
 	}
 

--- a/includes/class-support-overrides.php
+++ b/includes/class-support-overrides.php
@@ -38,6 +38,9 @@ class NerdPress_Support_Overrides {
 	public function hide_logtivity_settings() {
 		if ( ! NerdPress_Helpers::is_nerdpress() ) {
 			remove_submenu_page( 'logs', 'logtivity-settings' );
+			remove_submenu_page( 'lgtvy-logs', 'logtivity-settings' );
+			add_filter('logtivity_hide_settings_page', 'not_np_hide_logs');
+			function not_np_hide_logs(){ return true; }
 		}
 	}
 


### PR DESCRIPTION
Hid Settings in the submenu for non-NerdPress users and Settings link in the Plugins page with a filter in the Logtivity plugin. 

