### PR TITLE
2.3 release

### DIFF
--- a/blog-tutor-support.php
+++ b/blog-tutor-support.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name: NerdPress Support
  * Description: Helps your site work with our custom Cloudflare Enterprise setup or the Sucuri Firewall, and adds the "NerdPress Help" button in your dashboard.
- * Version:     2.2
+ * Version:     2.3-beta1
  * Author:      NerdPress
  * Author URI:  https://www.nerdpress.net
  * GitHub URI:  blogtutor/blog-tutor-support
@@ -20,7 +20,7 @@ include( dirname( __FILE__ ) . '/github-updater.php' );
 include( dirname( __FILE__ ) . '/includes/admin-menu.php' );
 
 if ( ! defined( 'BT_PLUGIN_VERSION' ) ) {
-	define( 'BT_PLUGIN_VERSION', '2.2' );
+	define( 'BT_PLUGIN_VERSION', '2.3-beta1' );
 }
 
 if ( ! class_exists( 'NerdPress' ) ) {

--- a/blog-tutor-support.php
+++ b/blog-tutor-support.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name: NerdPress Support
  * Description: Helps your site work with our custom Cloudflare Enterprise setup or the Sucuri Firewall, and adds the "NerdPress Help" button in your dashboard.
- * Version:     2.3-beta1
+ * Version:     2.3
  * Author:      NerdPress
  * Author URI:  https://www.nerdpress.net
  * GitHub URI:  blogtutor/blog-tutor-support
@@ -20,7 +20,7 @@ include( dirname( __FILE__ ) . '/github-updater.php' );
 include( dirname( __FILE__ ) . '/includes/admin-menu.php' );
 
 if ( ! defined( 'BT_PLUGIN_VERSION' ) ) {
-	define( 'BT_PLUGIN_VERSION', '2.3-beta1' );
+	define( 'BT_PLUGIN_VERSION', '2.3' );
 }
 
 if ( ! class_exists( 'NerdPress' ) ) {

--- a/includes/admin/class-support-admin.php
+++ b/includes/admin/class-support-admin.php
@@ -154,6 +154,21 @@ class NerdPress_Admin {
 				'label' => __( 'Disable our hard coded list of excluded JS.', 'nerdpress-support' ),
 			)
 		);
+
+		// Add option to disable/enable excluding WP Rocket delay js list.
+		add_settings_field(
+			'imagify_deactivate_nextgen_images',
+			__( 'Imagify NextGen Images', 'nerdpress-support' ),
+			array( $this, 'checkbox_imagify_deactivate_nextgen_images_element_callback' ),
+			$settings_option,
+			'options_section',
+			array(
+				'menu'  => $settings_option,
+				'id'    => 'imagify_deactivate_nextgen_images',
+				'label' => __( 'Allow Imagify\'s NextGen image creation for WebP.', 'nerdpress-support' ),
+			)
+		);
+
 		// Add option to disable/enable ShortPixel bulk optimization.
 		add_settings_field(
 			'shortpixel_bulk_optimize',
@@ -431,6 +446,26 @@ class NerdPress_Admin {
 		include dirname( __FILE__ ) . '/views/html-exclude-wp-rocket-delay-js-field.php';
 
 	}
+
+	/**
+	 * Checkbox Exclude WP Rocket Delay JS element callback.
+	 *
+	 * @param array $args Callback arguments.
+	 */
+	public function checkbox_imagify_deactivate_nextgen_images_element_callback( $args ) {
+		$menu    = $args['menu'];
+		$id      = $args['id'];
+		$options = get_option( $menu );
+
+		if ( isset( $options[ $id ] ) ) {
+			$current = $options[ $id ];
+		} else {
+			$current = isset( $args['default'] ) ? $args['default'] : '0';
+		}
+		include dirname( __FILE__ ) . '/views/html-imagify-deactivate-nextgen-images-element-field.php';
+
+	}
+
 	/**
 	 * Checkbox ShortPixel Bulk Optimize element callback.
 	 *

--- a/includes/admin/class-support-admin.php
+++ b/includes/admin/class-support-admin.php
@@ -94,122 +94,9 @@ class NerdPress_Admin {
 		// Set Custom Fields cection.
 		add_settings_section(
 			'options_section',
-			__( 'NerdPress Support Section', 'nerdpress-support' ),
+			__( '', 'nerdpress-support' ),
 			array( $this, 'section_options_callback' ),
 			$settings_option
-		);
-
-		// Add option to disable/enable Core auto updates.
-		add_settings_field(
-			'auto_update_core',
-			__( 'Core Auto-Updates', 'nerdpress-support' ),
-			array( $this, 'checkbox_auto_update_core_element_callback' ),
-			$settings_option,
-			'options_section',
-			array(
-				'menu'  => $settings_option,
-				'id'    => 'auto_update_core',
-				'label' => __( 'Enable to allow major version auto-updates for Core.', 'nerdpress-support' ),
-			)
-		);
-
-		// Add option to disable/enable plugin auto updates.
-		add_settings_field(
-			'auto_update_plugins',
-			__( 'Plugin Auto-Updates', 'nerdpress-support' ),
-			array( $this, 'checkbox_auto_update_plugins_element_callback' ),
-			$settings_option,
-			'options_section',
-			array(
-				'menu'  => $settings_option,
-				'id'    => 'auto_update_plugins',
-				'label' => __( 'Enable core auto-update functionality for plugins.', 'nerdpress-support' ),
-			)
-		);
-
-		// Add option to disable/enable theme auto updates.
-		add_settings_field(
-			'auto_update_themes',
-			__( 'Theme Auto-Updates', 'nerdpress-support' ),
-			array( $this, 'checkbox_auto_update_themes_element_callback' ),
-			$settings_option,
-			'options_section',
-			array(
-				'menu'  => $settings_option,
-				'id'    => 'auto_update_themes',
-				'label' => __( 'Enable core auto-update functionality for themes.', 'nerdpress-support' ),
-			)
-		);
-
-		// Add option to disable/enable excluding WP Rocket delay js list.
-		add_settings_field(
-			'exclude_wp_rocket_delay_js',
-			__( 'WP Rocket Delay JS', 'nerdpress-support' ),
-			array( $this, 'checkbox_exclude_wp_rocket_delay_js_element_callback' ),
-			$settings_option,
-			'options_section',
-			array(
-				'menu'  => $settings_option,
-				'id'    => 'exclude_wp_rocket_delay_js',
-				'label' => __( 'Disable our hard coded list of excluded JS.', 'nerdpress-support' ),
-			)
-		);
-
-		// Add option to disable/enable excluding WP Rocket delay js list.
-		add_settings_field(
-			'imagify_deactivate_nextgen_images',
-			__( 'Imagify NextGen Images', 'nerdpress-support' ),
-			array( $this, 'checkbox_imagify_deactivate_nextgen_images_element_callback' ),
-			$settings_option,
-			'options_section',
-			array(
-				'menu'  => $settings_option,
-				'id'    => 'imagify_deactivate_nextgen_images',
-				'label' => __( 'Allow Imagify\'s NextGen image creation for WebP.', 'nerdpress-support' ),
-			)
-		);
-
-		// Add option to disable/enable ShortPixel bulk optimization.
-		add_settings_field(
-			'shortpixel_bulk_optimize',
-			__( 'ShortPixel Settings', 'nerdpress-support' ),
-			array( $this, 'checkbox_shortpixel_bulk_optimize_element_callback' ),
-			$settings_option,
-			'options_section',
-			array(
-				'menu'        => $settings_option,
-				'id'          => 'shortpixel_bulk_optimize',
-				'label'       => __( 'Un-hide ShortPixel settings for users.', 'nerdpress-support' ),
-				'description' => __( 'SHORTPIXEL_HIDE_API_KEY constant ' ),
-			)
-		);
-
-		// Add admin notice text area
-		add_settings_field(
-			'admin_notice',
-			__( 'NerdPress Support Notice', 'nerdpress-support' ),
-			array( $this, 'textarea_element_callback' ),
-			$settings_option,
-			'options_section',
-			array(
-				'menu'        => $settings_option,
-				'id'          => 'admin_notice',
-				'description' => __( 'Enter notice that will show for NerdPress admins only.', 'nerdpress-support' ),
-			)
-		);
-
-		// Add option to hide "Need Help?" tab in dashboard.
-		add_settings_field(
-			'hide_tab',
-			__( 'Hide Help Tab?', 'nerdpress-support' ),
-			array( $this, 'checkbox_element_callback' ),
-			$settings_option,
-			'options_section',
-			array(
-				'menu'  => $settings_option,
-				'id'    => 'hide_tab',
-				'label' => __( 'Hides the "Need Help?" tab in the bottom of the dashboard.', 'nerdpress-support' ),
-			)
 		);
 
 		// Add the choice of firewall option
@@ -272,7 +159,7 @@ class NerdPress_Admin {
 			)
 		);
 
-		add_settings_field(
+    add_settings_field(
 			'np_relay_api_token',
 			__( 'NerdPress Relay API Token', 'nerdpress-support' ),
 			array( $this, 'nerdpress_relay_api_token_element_callback' ),
@@ -282,6 +169,118 @@ class NerdPress_Admin {
 				'menu'  => $settings_option,
 				'id'    => 'np_relay_api_token',
 				'label' => __( 'NerdPress Relay API Token', 'nerdpress-support' ),
+			)
+		);
+
+		// Add admin notice text area
+		add_settings_field(
+			'admin_notice',
+			__( 'NerdPress Support Notice', 'nerdpress-support' ),
+			array( $this, 'textarea_element_callback' ),
+			$settings_option,
+			'options_section',
+			array(
+				'menu'        => $settings_option,
+				'id'          => 'admin_notice',
+				'description' => __( 'Enter notice that will show for NerdPress admins only.', 'nerdpress-support' ),
+			)
+		);
+
+		// Add option to disable/enable Core auto updates.
+		add_settings_field(
+			'auto_update_core',
+			__( 'Core Auto-Updates', 'nerdpress-support' ),
+			array( $this, 'checkbox_auto_update_core_element_callback' ),
+			$settings_option,
+			'options_section',
+			array(
+				'menu'  => $settings_option,
+				'id'    => 'auto_update_core',
+				'label' => __( 'Enable to allow major version auto-updates for Core.', 'nerdpress-support' ),
+			)
+		);
+
+		// Add option to disable/enable plugin auto updates.
+		add_settings_field(
+			'auto_update_plugins',
+			__( 'Plugin Auto-Updates', 'nerdpress-support' ),
+			array( $this, 'checkbox_auto_update_plugins_element_callback' ),
+			$settings_option,
+			'options_section',
+			array(
+				'menu'  => $settings_option,
+				'id'    => 'auto_update_plugins',
+				'label' => __( 'Enable core auto-update functionality for plugins.', 'nerdpress-support' ),
+			)
+		);
+
+		// Add option to disable/enable theme auto updates.
+		add_settings_field(
+			'auto_update_themes',
+			__( 'Theme Auto-Updates', 'nerdpress-support' ),
+			array( $this, 'checkbox_auto_update_themes_element_callback' ),
+			$settings_option,
+			'options_section',
+			array(
+				'menu'  => $settings_option,
+				'id'    => 'auto_update_themes',
+				'label' => __( 'Enable core auto-update functionality for themes.', 'nerdpress-support' ),
+			)
+		);
+
+		// Add option to disable/enable excluding WP Rocket delay js list.
+		add_settings_field(
+			'exclude_wp_rocket_delay_js',
+			__( 'WP Rocket Delay JS', 'nerdpress-support' ),
+			array( $this, 'checkbox_exclude_wp_rocket_delay_js_element_callback' ),
+			$settings_option,
+			'options_section',
+			array(
+				'menu'  => $settings_option,
+				'id'    => 'exclude_wp_rocket_delay_js',
+				'label' => __( 'Disable our hard coded list of excluded JS.', 'nerdpress-support' ),
+			)
+		);
+		// Add option to disable/enable ShortPixel bulk optimization.
+		add_settings_field(
+			'shortpixel_bulk_optimize',
+			__( 'ShortPixel Settings', 'nerdpress-support' ),
+			array( $this, 'checkbox_shortpixel_bulk_optimize_element_callback' ),
+			$settings_option,
+			'options_section',
+			array(
+				'menu'        => $settings_option,
+				'id'          => 'shortpixel_bulk_optimize',
+				'label'       => __( 'Un-hide ShortPixel settings for users.', 'nerdpress-support' ),
+				'description' => __( 'SHORTPIXEL_HIDE_API_KEY constant ' ),
+			)
+		);
+
+		// Add option to disable/enable excluding WP Rocket delay js list.
+		add_settings_field(
+			'imagify_deactivate_nextgen_images',
+			__( 'Imagify NextGen Images', 'nerdpress-support' ),
+			array( $this, 'checkbox_imagify_deactivate_nextgen_images_element_callback' ),
+			$settings_option,
+			'options_section',
+			array(
+				'menu'  => $settings_option,
+				'id'    => 'imagify_deactivate_nextgen_images',
+				'label' => __( 'Allow Imagify\'s NextGen image creation for WebP.', 'nerdpress-support' ),
+			)
+		);
+
+		// Add option to hide "Need Help?" tab in dashboard.
+		add_settings_field(
+			'hide_tab',
+			__( 'Hide Help Tab?', 'nerdpress-support' ),
+			array( $this, 'checkbox_element_callback' ),
+			$settings_option,
+			'options_section',
+			array(
+				'menu'  => $settings_option,
+				'id'    => 'hide_tab',
+				'label' => __( 'Hides the "Need Help?" tab in the bottom of the dashboard.', 'nerdpress-support' ),
 			)
 		);
 
@@ -295,7 +294,7 @@ class NerdPress_Admin {
 		// Set Custom Fields section.
 		add_settings_section(
 			'information_section',
-			__( 'NerdPress Server Information Section', 'nerdpress-support' ),
+			__( '', 'nerdpress-support' ),
 			array( $this, 'section_options_callback' ),
 			$information_option
 		);
@@ -326,7 +325,7 @@ class NerdPress_Admin {
 			// Set Custom Fields cection.
 			add_settings_section(
 				'information_section',
-				__( 'Sucuri settings Section', 'nerdpress-support' ),
+				__( '', 'nerdpress-support' ),
 				array( $this, 'section_options_callback' ),
 				$sucuri_option
 			);

--- a/includes/admin/views/html-imagify-deactivate-nextgen-images-element-field.php
+++ b/includes/admin/views/html-imagify-deactivate-nextgen-images-element-field.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Checkbox field view.
+ *
+ * @package NerdPress/Admin/View
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+?>
+<input type="checkbox" id="<?php echo esc_attr( $id ); ?>" name="<?php echo esc_attr( $menu ); ?>[<?php echo esc_attr( $id ); ?>]" value="1" <?php checked( 1, $current, true ); ?> />
+<?php if ( isset( $args['label'] ) ) : ?>
+	<label for="<?php echo esc_attr( $id ); ?>"><?php echo esc_html( $args['label'] ); ?></label>
+<?php endif;

--- a/includes/admin/views/html-settings-page.php
+++ b/includes/admin/views/html-settings-page.php
@@ -33,6 +33,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		?>
 		<form method="post" action="options.php">
 		<?php
+			submit_button();		
 			settings_fields( 'blog_tutor_support_settings' );
 			do_settings_sections( 'blog_tutor_support_settings' );
 			submit_button();

--- a/includes/class-support-overrides.php
+++ b/includes/class-support-overrides.php
@@ -31,6 +31,12 @@ class NerdPress_Support_Overrides {
 		if ( ! is_admin() && ! isset( self::$nerdpress_options['exclude_wp_rocket_delay_js'] ) ) {
 			add_filter( 'rocket_delay_js_exclusions', array( $this, 'nerdpress_override_rocket_delay_js_exclusions' ) );
 		}
+		if ( class_exists( '\Imagify\Plugin' ) ) {
+			$imagify_options = get_option( 'imagify_settings' );
+			if ( ( ! isset( $imagify_options["display_nextgen"] ) || 0 === $imagify_options["display_nextgen"] ) && ! isset( self::$nerdpress_options['imagify_deactivate_nextgen_images'] ) ) {
+				add_filter( 'imagify_nextgen_images_formats', array( $this, 'nerdpress_override_imagify_nextgen_images' ) );
+			}
+		}
 		add_action( 'settings_page_wprocket', array( $this, 'np_wprocket_scripts' ) );
 		if ( class_exists( 'WooCommerce' ) ) {
 			add_filter( 'woocommerce_background_image_regeneration', '__return_false' );
@@ -148,6 +154,14 @@ class NerdPress_Support_Overrides {
 		$excluded_strings[] = 'blogherads';
 		$excluded_strings[] = 'sheknows-infuse\.js';
 		return $excluded_strings;
+	}
+
+	public function nerdpress_override_imagify_nextgen_images( $formats ) {
+		if ( isset( $formats['webp'] ) ) {
+			unset( $formats['webp'] );
+		}
+
+		return $formats;
 	}
 
 	public function np_wprocket_scripts() {

--- a/includes/class-support-overrides.php
+++ b/includes/class-support-overrides.php
@@ -141,7 +141,6 @@ class NerdPress_Support_Overrides {
 		$excluded_strings[] = 'nutrifox';
 		$excluded_strings[] = 'flodesk';
 		$excluded_strings[] = 'cp-popup\.js'; // ConvertPro
-		$excluded_strings[] = 'wp-recipe-maker';
 		$excluded_strings[] = 'slickstream';
 		$excluded_strings[] = 'slick-film-strip';
 		$excluded_strings[] = 'social-pug';

--- a/includes/class-support-overrides.php
+++ b/includes/class-support-overrides.php
@@ -144,6 +144,9 @@ class NerdPress_Support_Overrides {
 		$excluded_strings[] = 'slickstream';
 		$excluded_strings[] = 'slick-film-strip';
 		$excluded_strings[] = 'social-pug';
+		$excluded_strings[] = 'shemedia';
+		$excluded_strings[] = 'blogherads';
+		$excluded_strings[] = 'sheknows-infuse\.js';
 		return $excluded_strings;
 	}
 

--- a/includes/js/bt-allowlist.js
+++ b/includes/js/bt-allowlist.js
@@ -25,7 +25,7 @@ jQuery(document).ready(function($) {
 				}
 				
 				if(npMsgString === null)
-					npMsgString = 'Your IP (' + ip +  ') has been automatically<br />added to the Sucuri Firewall allowlist for the next 24 hours';
+					npMsgString = 'Your IP (' + ip +  ') has been automatically<br />added to the Sucuri Firewall allowlist for the next 24 hours.';
 
 				allowlistNotify(npMsgString);
 			}
@@ -47,10 +47,10 @@ window.crNerdPressNotification = function(message) {
 		npBox.style.color = '#fff';
 		npBox.style.position = 'absolute';
 		npBox.style.top = '3rem';
-		npBox.style.right = '5rem';
+		npBox.style.right = '320px';
 		npBox.style.display = 'none';
 
 		document.body.appendChild(npBox);
 
-		jQuery(npBox).fadeIn(2000).delay(10000).fadeOut(6000); 
+		jQuery(npBox).fadeIn(1500).delay(6000).fadeOut(2000); 
 }

--- a/includes/js/np-wprocket.js
+++ b/includes/js/np-wprocket.js
@@ -2,6 +2,6 @@
 
 jQuery(document).ready(function($) {
     // Content to show before WPR excludes.
-    $('.wpr-field #exclude_defer_js').before('<p style="font-size:12px;margin-bottom:15px">👋 <b>Heyo!</b> NerdPress automatically adds exclusions here for Mediavine, Raptive (Adthrive), Google Analytics & Tag Manager, Slickstream, Nutrifox, Flodesk, ConvertPro, ConvertKit, and Hubbub (formerly Grow Social). No need to add those here. 😎</p>');
+    $('.wpr-field #delay_js_exclusions').before('<p style="font-size:12px;margin-bottom:15px">👋 <b>Heyo!</b> NerdPress automatically adds exclusions here for Mediavine, Raptive (Adthrive), Google Analytics & Tag Manager, Slickstream, Nutrifox, Flodesk, ConvertPro, ConvertKit, and Hubbub (formerly Grow Social). No need to add those here. 😎</p>');
 
 });

--- a/includes/js/np-wprocket.js
+++ b/includes/js/np-wprocket.js
@@ -2,6 +2,5 @@
 
 jQuery(document).ready(function($) {
     // Content to show before WPR excludes.
-    $('.wpr-field #delay_js_exclusions').before('<p style="font-size:12px;margin-bottom:15px">👋 <b>Heyo!</b> NerdPress automatically adds exclusions here for Mediavine, Raptive (Adthrive), Google Analytics & Tag Manager, Slickstream, Nutrifox, Flodesk, ConvertPro, ConvertKit, and Hubbub (formerly Grow Social). No need to add those here. 😎</p>');
-
+    $('.wpr-field #delay_js_exclusions').before('<p style="font-size:12px;margin-bottom:15px">👋 <b>Heyo!</b> NerdPress automatically adds exclusions here for Mediavine, Raptive (Adthrive), SheMedia, Google Analytics & Tag Manager, Slickstream, Nutrifox, Flodesk, ConvertPro, ConvertKit, and Hubbub. No need to add those here. 😎</p>');
 });

--- a/includes/js/np-wprocket.js
+++ b/includes/js/np-wprocket.js
@@ -2,5 +2,6 @@
 
 jQuery(document).ready(function($) {
     // Content to show before WPR excludes.
-    $('.wpr-field #delay_js_exclusions').before('<p style="font-size:12px;margin-bottom:15px">👋 <b>Heyo!</b> NerdPress automatically adds exclusions here for Mediavine, Raptive (Adthrive), SheMedia, Google Analytics & Tag Manager, Slickstream, Nutrifox, Flodesk, ConvertPro, ConvertKit, and Hubbub. No need to add those here. 😎</p>');
+    $('.wpr-field #delay_js_exclusions').before('<p style="background-color: #0F145B;color: #fff;font-size:12px;font-weight:500;margin-bottom:15px;padding:15px">👋 <span style="font-weight: 900; color: #43C1C5">Heyo!</span> NerdPress automatically adds exclusions here for Mediavine, Raptive (Adthrive), SheMedia, Google Analytics & Tag Manager, Slickstream, Nutrifox, Flodesk, ConvertPro, ConvertKit, and Hubbub. No need to add those here. 😎</p>');
+
 });


### PR DESCRIPTION
- Disabled Imagify's new automatic WebP generation in v2.2. (Closes #308)
- Removed WP Recipe Maker from our Delay JS Exclusion list. (Closes #306)
- Added BlogHer/SheMedia to our custom WP Rocket Delay JS Exclusion list. (Closes #295)
- Spruced up the note about our Delay JS Exclusion list, and moved it to the correct spot on the WP Rocket page. (Closes #301)
- Reorganized our settings page so we can scroll less and work faster. (Closes #296)