### PR TITLE
FEATURE: Add better theme information for relay (inactive and parent)

### DIFF
--- a/includes/class-support-snapshot.php
+++ b/includes/class-support-snapshot.php
@@ -162,13 +162,34 @@ class NerdPress_Support_Snapshot {
 		$dump['wp_users_can_register']     = ! ! get_option( 'users_can_register' );
 		$dump['wp_default_role']           = get_option( 'default_role' );
 		$dump['inactive_themes_data']      = wp_get_themes();
+		$dump['theme_information']         = [
+			"name" =>  $current_theme['Name'],
+			"version" => $current_theme['Version'],
+			"author" => $current_theme['Author'],
+			"inactive_themes_data" => [],
+		];
+		 if (! empty($current_theme->parent())) {
+			$dump['theme_information']['parent']['name'] = $current_theme->parent()->get('Name');
+			$dump['theme_information']['parent']['version'] = $current_theme->parent()->get('Version');
+			$dump['theme_information']['parent']['author'] = $current_theme->parent()->get('Author');
+		 }
 
-		// Removing the active theme from the theme data.
-		$i = -1;
+		// Removing the active theme from the theme data and getting info for inactive themes
 		foreach ( $dump['inactive_themes_data'] as $key => $value ) {
-			$i++;
-			if ( $value['Name'] === $current_theme['Name'] ) {
+			// add to inactive themes array
+			$dump['theme_information']['inactive_themes_data'][$key] = [
+				"name" =>  $value['Name'],
+				"version" => $value['Version'],
+				"author" => $value['Author'],
+			];
+			if (! empty($value->parent())) {
+				$dump['theme_information']['inactive_themes_data'][$key]['parent']['name'] = $value->parent()->get('Name');
+				$dump['theme_information']['inactive_themes_data'][$key]['parent']['version'] = $value->parent()->get('Version');
+				$dump['theme_information']['inactive_themes_data'][$key]['parent']['author'] = $value->parent()->get('Author');
+			 }
+			if ( $value['Name'] === $current_theme['Name'] || $value['Name'] === $dump['theme_information']['parent']['name']) {
 				unset( $dump['inactive_themes_data'][ $key ] );
+				unset( $dump['theme_information']['inactive_themes_data'][$key] );
 			}
 		}
 
@@ -176,7 +197,7 @@ class NerdPress_Support_Snapshot {
 		if ( isset( get_option( 'blog_tutor_support_settings' )['admin_notice'] ) ) {
 			$dump['notes'] = get_option( 'blog_tutor_support_settings' )['admin_notice'];
 		}
-
+		
 		return $dump;
 	}
 


### PR DESCRIPTION
This adds more information for the relay. We will now be able to implement a search for active themes (child and parent) or inactive themes (child and parent). We previously didn't have the parent information.

[For use with Relay PR here. ](https://github.com/blogtutor/np-dashboard/pull/337)