### PR TITLE
FIX: #339 & #347 - hide things unless nerdpress

### DIFF
--- a/includes/class-support-widget.php
+++ b/includes/class-support-widget.php
@@ -103,7 +103,7 @@ class NerdPress_Widget {
 			}(window, document, window.Beacon || function() {});
 		</script>
 		<?php
-		if ( is_admin() && ( ! isset( $options['hide_tab'] ) ) && ! defined('IFRAME_REQUEST') ) {
+		if ( is_admin() && ( ! isset( $options['hide_tab'] ) ) && ! defined('IFRAME_REQUEST') && ! NerdPress_Helpers::is_nerdpress() ) {
 			?>
 			<script type = "text/javascript">
 				<?php echo NerdPress_Helpers::$help_scout_widget_init; ?>

--- a/includes/class-support-widget.php
+++ b/includes/class-support-widget.php
@@ -38,6 +38,7 @@ class NerdPress_Widget {
 		if (
 			NerdPress_Helpers::is_relay_server_configured()
 			&& array_intersect( $allowed_roles, $user->roles )
+			&& NerdPress_Helpers::is_nerdpress()
 			) {
 			wp_add_dashboard_widget(
 				'nerdpress_widget',


### PR DESCRIPTION
Adds a is_nerdpress check to both the init of the HelpScout Widget and the NerdPress Status widget