### PR TITLE
FEATURE: Require more auth for is_nerdpress

### DIFF
--- a/blog-tutor-support.php
+++ b/blog-tutor-support.php
@@ -86,6 +86,7 @@ if ( ! class_exists( 'NerdPress' ) ) {
 			include_once dirname( __FILE__ ) . '/includes/class-support-widget.php';
 			include_once dirname( __FILE__ ) . '/includes/class-support-overrides.php';
 			include_once dirname( __FILE__ ) . '/includes/class-support-shortpixel.php';
+			include_once dirname( __FILE__ ) . '/includes/class-support-auth.php';
 
 			if ( NerdPress_Helpers::is_relay_server_configured() ) {
 				include_once dirname( __FILE__ ) . '/includes/class-support-snapshot.php';

--- a/includes/class-support-auth.php
+++ b/includes/class-support-auth.php
@@ -34,7 +34,7 @@ class NerdPress_Auth {
                 }
 
                 // Set the cookie for 12 hours
-                setcookie( 'NP_CF_Authorization', '1', time() + 12 * 60 * 60, '/', null, false, true );
+                setcookie( 'NP_CF_Authorization', md5( get_current_user_id() ), time() + 12 * 60 * 60, '/', null, false, true );
 
                 // remove set_cookie and nonce from the URL and reload the page
                 wp_safe_redirect( remove_query_arg( array( 'set_cookie', 'nonce' ), $_SERVER['REQUEST_URI'] ) );
@@ -59,7 +59,16 @@ class NerdPress_Auth {
      * @return bool True if the user has a valid CF_Authorization cookie, false otherwise.
      */
     function has_valid_cf_authorization_cookie() {
-        return isset( $_COOKIE['NP_CF_Authorization'] );
+        if ( isset( $_COOKIE['NP_CF_Authorization'] ) ) {
+            return false;
+        }
+
+        if ( md5( get_current_user_id() ) === $_COOKIE['NP_CF_Authorization'] ) {
+            return true;
+        }
+
+        return false;
+
     }
 }
 

--- a/includes/class-support-auth.php
+++ b/includes/class-support-auth.php
@@ -59,7 +59,7 @@ class NerdPress_Auth {
      * @return bool True if the user has a valid CF_Authorization cookie, false otherwise.
      */
     function has_valid_cf_authorization_cookie() {
-        if ( isset( $_COOKIE['NP_CF_Authorization'] ) ) {
+        if ( ! isset( $_COOKIE['NP_CF_Authorization'] ) ) {
             return false;
         }
 

--- a/includes/class-support-auth.php
+++ b/includes/class-support-auth.php
@@ -1,0 +1,66 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * NerdPress Auth.
+ *
+ * @package  NerdPress
+ * @category Auth
+ * @author   Brian Routzong
+ */
+class NerdPress_Auth {
+	/**
+	 * Initialize the auth class.
+	 */
+	public function __construct() {
+        add_action( 'admin_init', array( $this, 'redirect_if_not_authenticated' ) );
+    }
+
+    /**
+     * Redirect if the user is not authenticated.
+     */
+    function redirect_if_not_authenticated() {
+        // if we have a url parameter
+        if ( is_admin() && is_user_logged_in() && NerdPress_Helpers::is_nerdpress() && ! $this->has_valid_cf_authorization_cookie() ) {
+
+            if ( isset( $_GET['set_cookie'] ) && $_GET['set_cookie'] === 'true' ) {
+                //verify the nonce to prevent CSRF attacks
+
+                $nonce = wp_verify_nonce( $_GET['nonce'], 'cloudflare_cookie_redirect_'. get_current_user_id() );
+                if ( ! $nonce ) {
+                    wp_die( 'Invalid nonce when trying to set the NerdPress team member cookie.', 'NerdPress', array( 'response' => 403 ) );
+                }
+
+                // Set the cookie for 12 hours
+                setcookie( 'NP_CF_Authorization', '1', time() + 12 * 60 * 60, '/', null, false, true );
+
+                // remove set_cookie and nonce from the URL and reload the page
+                wp_safe_redirect( remove_query_arg( array( 'set_cookie', 'nonce' ), $_SERVER['REQUEST_URI'] ) );
+                exit;
+            }
+            // send the path and base domain as url paramaters to access.nerdpress.net
+            // Example: https://access.nerdpress.net?path=/wp-admin&base=example.com
+            $path = $_SERVER['REQUEST_URI'];
+            $base = parse_url( home_url(), PHP_URL_HOST );
+            $nonce = wp_create_nonce( 'cloudflare_cookie_redirect_' . get_current_user_id() );
+            $redirect_url = 'https://access.nerdpress.net?path='. urlencode( $path ). '&base_domain='. urlencode( $base ) . '&nonce='. $nonce;
+
+            // Redirect to the NerdPress access site
+            wp_redirect( $redirect_url );
+            exit;
+        }
+    }
+
+    /**
+     * Check if the user has a valid CF_Authorization cookie.
+     *
+     * @return bool True if the user has a valid CF_Authorization cookie, false otherwise.
+     */
+    function has_valid_cf_authorization_cookie() {
+        return isset( $_COOKIE['NP_CF_Authorization'] );
+    }
+}
+
+new NerdPress_Auth();


### PR DESCRIPTION
If a user is trying to access anything in the admin and the use is_nerdpress()...This will reach out to our custom page access.nerdpress.net, which is protected under Cloudflare Access requiring a Google Workspace authentication. If Cloudflare Access allows you to see that page, and the correct URL parameters are passed, you will be redirected back to the client WordPress site where another cookie is set for 12 hours to keep you from having to do this check too often. 